### PR TITLE
Omit the event plot when running the demo on Windows

### DIFF
--- a/src/textual_plotext/__main__.py
+++ b/src/textual_plotext/__main__.py
@@ -20,6 +20,7 @@ it will show a demonstration of the library in action.
 
 from __future__ import annotations
 
+import os
 import random
 from datetime import datetime
 from itertools import chain, cycle
@@ -320,7 +321,7 @@ class SpecialPlots(ExamplesPane):
             "special",
             [
                 self.ErrorPlot(),
-                self.EventPlot(),
+                *([] if os.name == "nt" else [self.EventPlot()]),
                 self.StreamingDataPlot(),
                 self.MatrixPlot(),
                 self.ConfusionMatrix(),


### PR DESCRIPTION
See #7 and https://github.com/piccolomo/plotext/issues/189 -- this seems to be an issue somewhere between Plotext itself and Python on Windows; while we could dive into this and try and solve it, for the purposes of a quick demo it makes more sense to remove the problematic plot for now.