### PR TITLE
Relax textual dependency specification to allow newer textual versions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # textual-plotext ChangeLog
 
+## [1.0.1] - 2024-11-29
+- Relax `textual` dependency to allow for newer textual versions
+
+## [1.0.0] - 2024-11-21
+- Update to use new theme-feature of `textual`
+
 ## [0.2.1] - 2023-10-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textual-plotext"
-version = "1.0.0"
+version = "1.0.1"
 description = "A Textual widget wrapper for the Plotext plotting library"
 homepage = "https://github.com/Textualize/textual-plotext"
 repository = "https://github.com/Textualize/textual-plotext"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.8.1"
 plotext = "^5.2.8"
-textual = "^0.86.2"
+textual = ">=0.86.2"
 
 [tool.poetry.group.dev.dependencies]
 textual-dev = "*"


### PR DESCRIPTION
The version constraint for textual plotext `textual = "^0.86.2"`  is limiting the textual version to `<0.87.0`  since textual is currently still `0.x.x` (cause of leading zero version, see [poetry docs](https://python-poetry.org/docs/dependency-specification/#caret-requirements))

Changed it to an inequality requirement  `>=0.86.2`  instead of the  carrot requirement type, to allow newer textual versions. 